### PR TITLE
CI: Add Node 17.x to matrix

### DIFF
--- a/.github/workflows/test-javascript.yaml
+++ b/.github/workflows/test-javascript.yaml
@@ -14,12 +14,16 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version: ['12.x', '14.x', '16.x']
+        node-version: ['12.x', '14.x', '16.x', '17.x']
         include:
           - os: windows-latest
             node-version: '16.x'
           - os: macos-latest
             node-version: '16.x'
+          - os: windows-latest
+            node-version: '17.x'
+          - os: macos-latest
+            node-version: '17.x'
 
     steps:
       - name: set git core.autocrlf to 'input'


### PR DESCRIPTION
# Description

This PR adds the Node 17.x build target, for Ubuntu, Windows and macOS.

# Motivation & context

I asked in Slack, https://cucumberbdd.slack.com/archives/C612KCP1P/p1643968857727739 what are the supported versions of Node.js? ("Which versions are deemed ancient?")

It was found that 17.x was not in the build matrix.

## Question

Should we quell 16.x's building on Windows+macOS, now that 17.x is the latest release? 16.x is the LTS, hmm. Perhaps 17.x shouldn't run on anything but Ubuntu? What are your thoughts about this?

## Type of change

- Refactoring/debt - ensuring that we run on latest Node.js major release

# Checklist:


- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
