### PR TITLE
Fix TS7030 by returning void in all code paths (for Express return type)

### DIFF
--- a/features/src/server.ts
+++ b/features/src/server.ts
@@ -22,7 +22,8 @@ export function makeApp(shouty: Shouty) {
     const { userId } = req.query
     const session = shouty.getSession(userId as string)
     if (!session) {
-      return res.status(500).end(`No session for userId=${userId}`)
+      res.status(500).end(`No session for userId=${userId}`)
+      return
     }
     const sse = new SseStream(req)
 
@@ -39,8 +40,6 @@ export function makeApp(shouty: Shouty) {
       sse.unpipe(res)
       res.end()
     })
-
-    return null
   })
 
   return exp

--- a/features/src/server.ts
+++ b/features/src/server.ts
@@ -39,6 +39,8 @@ export function makeApp(shouty: Shouty) {
       sse.unpipe(res)
       res.end()
     })
+
+    return null
   })
 
   return exp


### PR DESCRIPTION
### 🤔 What's changed?

I have added a return value to a callback which seemed to need one, according to TS7030.

I picked the return value `null` to make it a... simple value.

**Update**: The problem was simpler: one of the code paths made an early return in a way which _actually returned a non-void value_.

### ⚡️ What's your motivation? 

This issue came up when running "npm run build" for the PR #74 about updating @types/node to v16.11.25.

Here is some output:

> ➜  screenplay.js git:(renovate/node-16.x) npm run build
> 
> > @cucumber/screenplay@5.1.0 build
> > tsc --build tsconfig.json
> 
> features/src/server.ts:20:24 - error TS7030: Not all code paths return a value.
> 
> 20   exp.get('/messages', (req, res) => {
>                           ~~~~~~~~~~~~~~~
> 
> 
> Found 1 error.
> 

With this, I can run the `npm run build` in the #74 Pull Request.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
